### PR TITLE
Fix: Git thinks a directory is unsafe

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -95,5 +95,6 @@ RUN ln -s /usr/aarch64-linux-gnu/lib/libpcre.so /usr/lib/gcc-cross/aarch64-linux
 ADD .cargo_config /root/.cargo/config
 
 RUN mkdir -p /home/rust/libs /home/rust/src
+RUN git config --global --add safe.directory /home/rust/src
 
 WORKDIR /home/rust/src


### PR DESCRIPTION
Given that during the building of the embassy os backend, `git_version::git_version!(args = ["--always", "--abbrev=40", "--dirty=-modified"])`
I searched online and found `https://github.com/actions/checkout/issues/760` to have the solution that I needed to fix